### PR TITLE
Fix: References after move to @ergebnis

### DIFF
--- a/.php_cs
+++ b/.php_cs
@@ -8,7 +8,7 @@ declare(strict_types=1);
  * For the full copyright and license information, please view
  * the LICENSE file that was distributed with this source code.
  *
- * @see https://github.com/localheinz/test-util
+ * @see https://github.com/ergebnis/test-util
  */
 
 use Ergebnis\PhpCsFixer\Config;
@@ -19,7 +19,7 @@ Copyright (c) 2017 Andreas Möller
 For the full copyright and license information, please view
 the LICENSE file that was distributed with this source code.
 
-@see https://github.com/localheinz/test-util
+@see https://github.com/ergebnis/test-util
 EOF;
 
 $config = Config\Factory::fromRuleSet(new Config\RuleSet\Php71($header));

--- a/.php_cs.fixture
+++ b/.php_cs.fixture
@@ -8,7 +8,7 @@ declare(strict_types=1);
  * For the full copyright and license information, please view
  * the LICENSE file that was distributed with this source code.
  *
- * @see https://github.com/localheinz/test-util
+ * @see https://github.com/ergebnis/test-util
  */
 
 use Ergebnis\PhpCsFixer\Config;

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -19,14 +19,14 @@ For a full diff see [`0.7.0...0.8.0`][0.7.0...0.8.0].
 * Dropped support for `phpunit/phpunit:^6.0.0` ([#120]), by [@localheinz]
 * Allowed installation with `phpunit/phpunit:^8.0.0` ([#122]), by [@localheinz]
 
-[0.8.0]: https://github.com/localheinz/test-util/releases/tag/0.8.0
+[0.8.0]: https://github.com/ergebnis/test-util/releases/tag/0.8.0
 
-[0.7.0...0.8.0]: https://github.com/localheinz/test-util/compare/0.7.0...0.8.0
-[0.8.0...master]: https://github.com/localheinz/test-util/compare/0.8.0...master
+[0.7.0...0.8.0]: https://github.com/ergebnis/test-util/compare/0.7.0...0.8.0
+[0.8.0...master]: https://github.com/ergebnis/test-util/compare/0.8.0...master
 
-[#118]: https://github.com/localheinz/test-util/pull/118
-[#119]: https://github.com/localheinz/test-util/pull/119
-[#120]: https://github.com/localheinz/test-util/pull/120
-[#122]: https://github.com/localheinz/test-util/pull/122
+[#118]: https://github.com/ergebnis/test-util/pull/118
+[#119]: https://github.com/ergebnis/test-util/pull/119
+[#120]: https://github.com/ergebnis/test-util/pull/120
+[#122]: https://github.com/ergebnis/test-util/pull/122
 
 [@localheinz]: https://github.com/localheinz

--- a/README.md
+++ b/README.md
@@ -1,9 +1,9 @@
 # test-util
 
-[![continuous Integration](https://github.com/localheinz/test-util/workflows/Continuous%20Integration/badge.svg)](https://github.com/localheinz/test-util/actions)
-[![codecov](https://codecov.io/gh/localheinz/test-util/branch/master/graph/badge.svg)](https://codecov.io/gh/localheinz/test-util)
-[![Latest Stable Version](https://poser.pugx.org/localheinz/test-util/v/stable)](https://packagist.org/packages/localheinz/test-util)
-[![Total Downloads](https://poser.pugx.org/localheinz/test-util/downloads)](https://packagist.org/packages/localheinz/test-util)
+[![continuous Integration](https://github.com/ergebnis/test-util/workflows/Continuous%20Integration/badge.svg)](https://github.com/ergebnis/test-util/actions)
+[![codecov](https://codecov.io/gh/ergebnis/test-util/branch/master/graph/badge.svg)](https://codecov.io/gh/localheinz/test-util)
+[![Latest Stable Version](https://poser.pugx.org/ergebnis/test-util/v/stable)](https://packagist.org/packages/localheinz/test-util)
+[![Total Downloads](https://poser.pugx.org/ergebnis/test-util/downloads)](https://packagist.org/packages/localheinz/test-util)
 
 Provides utilities for tests.
 

--- a/composer.json
+++ b/composer.json
@@ -46,7 +46,7 @@
     }
   },
   "support": {
-    "issues": "https://github.com/localheinz/test-util/issues",
+    "issues": "https://github.com/ergebnis/test-util/issues",
     "source": "https://github.com/localheinz/test-util"
   }
 }

--- a/src/Exception/InvalidExcludeClassName.php
+++ b/src/Exception/InvalidExcludeClassName.php
@@ -8,7 +8,7 @@ declare(strict_types=1);
  * For the full copyright and license information, please view
  * the LICENSE file that was distributed with this source code.
  *
- * @see https://github.com/localheinz/test-util
+ * @see https://github.com/ergebnis/test-util
  */
 
 namespace Localheinz\Test\Util\Exception;

--- a/src/Exception/NonExistentDirectory.php
+++ b/src/Exception/NonExistentDirectory.php
@@ -8,7 +8,7 @@ declare(strict_types=1);
  * For the full copyright and license information, please view
  * the LICENSE file that was distributed with this source code.
  *
- * @see https://github.com/localheinz/test-util
+ * @see https://github.com/ergebnis/test-util
  */
 
 namespace Localheinz\Test\Util\Exception;

--- a/src/Exception/NonExistentExcludeClass.php
+++ b/src/Exception/NonExistentExcludeClass.php
@@ -8,7 +8,7 @@ declare(strict_types=1);
  * For the full copyright and license information, please view
  * the LICENSE file that was distributed with this source code.
  *
- * @see https://github.com/localheinz/test-util
+ * @see https://github.com/ergebnis/test-util
  */
 
 namespace Localheinz\Test\Util\Exception;

--- a/src/Helper.php
+++ b/src/Helper.php
@@ -8,7 +8,7 @@ declare(strict_types=1);
  * For the full copyright and license information, please view
  * the LICENSE file that was distributed with this source code.
  *
- * @see https://github.com/localheinz/test-util
+ * @see https://github.com/ergebnis/test-util
  */
 
 namespace Localheinz\Test\Util;

--- a/test/AutoReview/SrcCodeTest.php
+++ b/test/AutoReview/SrcCodeTest.php
@@ -8,7 +8,7 @@ declare(strict_types=1);
  * For the full copyright and license information, please view
  * the LICENSE file that was distributed with this source code.
  *
- * @see https://github.com/localheinz/test-util
+ * @see https://github.com/ergebnis/test-util
  */
 
 namespace Localheinz\Test\Util\Test\AutoReview;

--- a/test/AutoReview/TestCodeTest.php
+++ b/test/AutoReview/TestCodeTest.php
@@ -8,7 +8,7 @@ declare(strict_types=1);
  * For the full copyright and license information, please view
  * the LICENSE file that was distributed with this source code.
  *
- * @see https://github.com/localheinz/test-util
+ * @see https://github.com/ergebnis/test-util
  */
 
 namespace Localheinz\Test\Util\Test\AutoReview;

--- a/test/Unit/Exception/InvalidExcludeClassNameTest.php
+++ b/test/Unit/Exception/InvalidExcludeClassNameTest.php
@@ -8,7 +8,7 @@ declare(strict_types=1);
  * For the full copyright and license information, please view
  * the LICENSE file that was distributed with this source code.
  *
- * @see https://github.com/localheinz/test-util
+ * @see https://github.com/ergebnis/test-util
  */
 
 namespace Localheinz\Test\Util\Test\Unit\Exception;

--- a/test/Unit/Exception/NonExistentDirectoryTest.php
+++ b/test/Unit/Exception/NonExistentDirectoryTest.php
@@ -8,7 +8,7 @@ declare(strict_types=1);
  * For the full copyright and license information, please view
  * the LICENSE file that was distributed with this source code.
  *
- * @see https://github.com/localheinz/test-util
+ * @see https://github.com/ergebnis/test-util
  */
 
 namespace Localheinz\Test\Util\Test\Unit\Exception;

--- a/test/Unit/Exception/NonExistentExcludeClassTest.php
+++ b/test/Unit/Exception/NonExistentExcludeClassTest.php
@@ -8,7 +8,7 @@ declare(strict_types=1);
  * For the full copyright and license information, please view
  * the LICENSE file that was distributed with this source code.
  *
- * @see https://github.com/localheinz/test-util
+ * @see https://github.com/ergebnis/test-util
  */
 
 namespace Localheinz\Test\Util\Test\Unit\Exception;

--- a/test/Unit/HelperTest.php
+++ b/test/Unit/HelperTest.php
@@ -8,7 +8,7 @@ declare(strict_types=1);
  * For the full copyright and license information, please view
  * the LICENSE file that was distributed with this source code.
  *
- * @see https://github.com/localheinz/test-util
+ * @see https://github.com/ergebnis/test-util
  */
 
 namespace Localheinz\Test\Util\Test\Unit;


### PR DESCRIPTION
This PR

* [x] fixes references after the move to @ergebnis