### PR TITLE
Fix: References after move to @ergebnis

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -1,5 +1,5 @@
 {
-  "name": "localheinz/test-util",
+  "name": "ergebnis/test-util",
   "type": "library",
   "description": "Provides utilities for tests.",
   "keywords": [
@@ -8,7 +8,7 @@
     "phpunit",
     "test"
   ],
-  "homepage": "https://github.com/localheinz/test-util",
+  "homepage": "https://github.com/ergebnis/test-util",
   "license": "MIT",
   "authors": [
     {
@@ -47,6 +47,6 @@
   },
   "support": {
     "issues": "https://github.com/ergebnis/test-util/issues",
-    "source": "https://github.com/localheinz/test-util"
+    "source": "https://github.com/ergebnis/test-util"
   }
 }

--- a/composer.lock
+++ b/composer.lock
@@ -4,7 +4,7 @@
         "Read more about it at https://getcomposer.org/doc/01-basic-usage.md#installing-dependencies",
         "This file is @generated automatically"
     ],
-    "content-hash": "889d3284e1d485e7bbdf8663eafe3c5e",
+    "content-hash": "8e9d1898737431ea72ef75ca7e2eb2eb",
     "packages": [
         {
             "name": "ergebnis/classy",


### PR DESCRIPTION
This PR

* [x] fixes references after the move to @ergebnis

Follows #143.