### PR TITLE
Enhancement: Rename namespace after move to @ergebnis

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,8 +6,16 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 
 ## Unreleased
 
-For a full diff see [`0.8.0...master`][0.8.0...master].
+For a full diff see [`0.9.0...master`][0.9.0...master].
 
+## [`0.9.0`][0.9.0]
+
+For a full diff see [`0.8.0...0.9.0`][0.8.0...0.9.0].
+
+### Changed
+
+* Renamed vendor namespace `Localheinz` to `Ergebnis` after move to [@ergebnis] ([#147]), by [@localheinz]
+*
 ## [`0.8.0`][0.8.0]
 
 For a full diff see [`0.7.0...0.8.0`][0.7.0...0.8.0].
@@ -22,11 +30,14 @@ For a full diff see [`0.7.0...0.8.0`][0.7.0...0.8.0].
 [0.8.0]: https://github.com/ergebnis/test-util/releases/tag/0.8.0
 
 [0.7.0...0.8.0]: https://github.com/ergebnis/test-util/compare/0.7.0...0.8.0
-[0.8.0...master]: https://github.com/ergebnis/test-util/compare/0.8.0...master
+[0.8.0...0.9.0]: https://github.com/ergebnis/test-util/compare/0.8.0...0.9.0
+[0.9.0...master]: https://github.com/ergebnis/test-util/compare/0.9.0...master
 
 [#118]: https://github.com/ergebnis/test-util/pull/118
 [#119]: https://github.com/ergebnis/test-util/pull/119
 [#120]: https://github.com/ergebnis/test-util/pull/120
 [#122]: https://github.com/ergebnis/test-util/pull/122
+[#147]: https://github.com/ergebnis/test-util/pull/147
 
+[@ergebnis]: https://github.com/ergebnis
 [@localheinz]: https://github.com/localheinz

--- a/README.md
+++ b/README.md
@@ -17,7 +17,7 @@ $ composer require --dev ergebnis/test-util
 
 ## Usage
 
-Import the `Localheinz\Test\Util\Helper` trait into your test class:
+Import the `Ergebnis\Test\Util\Helper` trait into your test class:
 
 ```php
 <?php
@@ -26,7 +26,7 @@ declare(strict_types=1);
 
 namespace Foo\Bar\Test\Unit;
 
-use Localheinz\Test\Util\Helper;
+use Ergebnis\Test\Util\Helper;
 use PHPUnit\Framework;
 
 final class BazTest extends Framework\TestCase
@@ -48,8 +48,8 @@ declare(strict_types=1);
 
 namespace Example\Test\Unit;
 
+use Ergebnis\Test\Util\Helper;
 use Example\Player;
-use Localheinz\Test\Util\Helper;
 use PHPUnit\Framework;
 
 final class PlayerTest extends Framework\TestCase

--- a/composer.json
+++ b/composer.json
@@ -37,12 +37,12 @@
   },
   "autoload": {
     "psr-4": {
-      "Localheinz\\Test\\Util\\": "src/"
+      "Ergebnis\\Test\\Util\\": "src/"
     }
   },
   "autoload-dev": {
     "psr-4": {
-      "Localheinz\\Test\\Util\\Test\\": "test/"
+      "Ergebnis\\Test\\Util\\Test\\": "test/"
     }
   },
   "support": {

--- a/src/Exception/InvalidExcludeClassName.php
+++ b/src/Exception/InvalidExcludeClassName.php
@@ -11,7 +11,7 @@ declare(strict_types=1);
  * @see https://github.com/ergebnis/test-util
  */
 
-namespace Localheinz\Test\Util\Exception;
+namespace Ergebnis\Test\Util\Exception;
 
 /**
  * @internal

--- a/src/Exception/NonExistentDirectory.php
+++ b/src/Exception/NonExistentDirectory.php
@@ -11,7 +11,7 @@ declare(strict_types=1);
  * @see https://github.com/ergebnis/test-util
  */
 
-namespace Localheinz\Test\Util\Exception;
+namespace Ergebnis\Test\Util\Exception;
 
 /**
  * @internal

--- a/src/Exception/NonExistentExcludeClass.php
+++ b/src/Exception/NonExistentExcludeClass.php
@@ -11,7 +11,7 @@ declare(strict_types=1);
  * @see https://github.com/ergebnis/test-util
  */
 
-namespace Localheinz\Test\Util\Exception;
+namespace Ergebnis\Test\Util\Exception;
 
 /**
  * @internal

--- a/src/Helper.php
+++ b/src/Helper.php
@@ -11,7 +11,7 @@ declare(strict_types=1);
  * @see https://github.com/ergebnis/test-util
  */
 
-namespace Localheinz\Test\Util;
+namespace Ergebnis\Test\Util;
 
 use Ergebnis\Classy;
 use Faker\Factory;

--- a/test/AutoReview/SrcCodeTest.php
+++ b/test/AutoReview/SrcCodeTest.php
@@ -11,9 +11,9 @@ declare(strict_types=1);
  * @see https://github.com/ergebnis/test-util
  */
 
-namespace Localheinz\Test\Util\Test\AutoReview;
+namespace Ergebnis\Test\Util\Test\AutoReview;
 
-use Localheinz\Test\Util\Helper;
+use Ergebnis\Test\Util\Helper;
 use PHPUnit\Framework;
 
 /**
@@ -34,8 +34,8 @@ final class SrcCodeTest extends Framework\TestCase
     {
         self::assertClassesHaveTests(
             __DIR__ . '/../../src',
-            'Localheinz\\Test\\Util\\',
-            'Localheinz\\Test\\Util\\Test\\Unit\\'
+            'Ergebnis\\Test\\Util\\',
+            'Ergebnis\\Test\\Util\\Test\\Unit\\'
         );
     }
 }

--- a/test/AutoReview/TestCodeTest.php
+++ b/test/AutoReview/TestCodeTest.php
@@ -11,10 +11,10 @@ declare(strict_types=1);
  * @see https://github.com/ergebnis/test-util
  */
 
-namespace Localheinz\Test\Util\Test\AutoReview;
+namespace Ergebnis\Test\Util\Test\AutoReview;
 
-use Localheinz\Test\Util\Helper;
-use Localheinz\Test\Util\Test\Fixture;
+use Ergebnis\Test\Util\Helper;
+use Ergebnis\Test\Util\Test\Fixture;
 use PHPUnit\Framework;
 
 /**

--- a/test/Fixture/ClassExists/ExampleClass.php
+++ b/test/Fixture/ClassExists/ExampleClass.php
@@ -2,7 +2,7 @@
 
 declare(strict_types=1);
 
-namespace Localheinz\Test\Util\Test\Fixture\ClassExists;
+namespace Ergebnis\Test\Util\Test\Fixture\ClassExists;
 
 final class ExampleClass
 {

--- a/test/Fixture/ClassExtends/ChildClass.php
+++ b/test/Fixture/ClassExtends/ChildClass.php
@@ -2,7 +2,7 @@
 
 declare(strict_types=1);
 
-namespace Localheinz\Test\Util\Test\Fixture\ClassExtends;
+namespace Ergebnis\Test\Util\Test\Fixture\ClassExtends;
 
 final class ChildClass extends ParentClass
 {

--- a/test/Fixture/ClassExtends/ParentClass.php
+++ b/test/Fixture/ClassExtends/ParentClass.php
@@ -2,7 +2,7 @@
 
 declare(strict_types=1);
 
-namespace Localheinz\Test\Util\Test\Fixture\ClassExtends;
+namespace Ergebnis\Test\Util\Test\Fixture\ClassExtends;
 
 abstract class ParentClass
 {

--- a/test/Fixture/ClassExtends/UnrelatedClass.php
+++ b/test/Fixture/ClassExtends/UnrelatedClass.php
@@ -2,7 +2,7 @@
 
 declare(strict_types=1);
 
-namespace Localheinz\Test\Util\Test\Fixture\ClassExtends;
+namespace Ergebnis\Test\Util\Test\Fixture\ClassExtends;
 
 final class UnrelatedClass
 {

--- a/test/Fixture/ClassIsAbstract/AbstractClass.php
+++ b/test/Fixture/ClassIsAbstract/AbstractClass.php
@@ -2,7 +2,7 @@
 
 declare(strict_types=1);
 
-namespace Localheinz\Test\Util\Test\Fixture\ClassIsAbstract;
+namespace Ergebnis\Test\Util\Test\Fixture\ClassIsAbstract;
 
 abstract class AbstractClass
 {

--- a/test/Fixture/ClassIsAbstract/ConcreteClass.php
+++ b/test/Fixture/ClassIsAbstract/ConcreteClass.php
@@ -2,7 +2,7 @@
 
 declare(strict_types=1);
 
-namespace Localheinz\Test\Util\Test\Fixture\ClassIsAbstract;
+namespace Ergebnis\Test\Util\Test\Fixture\ClassIsAbstract;
 
 class ConcreteClass
 {

--- a/test/Fixture/ClassIsFinal/AbstractClass.php
+++ b/test/Fixture/ClassIsFinal/AbstractClass.php
@@ -2,7 +2,7 @@
 
 declare(strict_types=1);
 
-namespace Localheinz\Test\Util\Test\Fixture\ClassIsFinal;
+namespace Ergebnis\Test\Util\Test\Fixture\ClassIsFinal;
 
 abstract class AbstractClass
 {

--- a/test/Fixture/ClassIsFinal/FinalClass.php
+++ b/test/Fixture/ClassIsFinal/FinalClass.php
@@ -2,7 +2,7 @@
 
 declare(strict_types=1);
 
-namespace Localheinz\Test\Util\Test\Fixture\ClassIsFinal;
+namespace Ergebnis\Test\Util\Test\Fixture\ClassIsFinal;
 
 final class FinalClass
 {

--- a/test/Fixture/ClassIsFinal/NeitherAbstractNorFinalClass.php
+++ b/test/Fixture/ClassIsFinal/NeitherAbstractNorFinalClass.php
@@ -2,7 +2,7 @@
 
 declare(strict_types=1);
 
-namespace Localheinz\Test\Util\Test\Fixture\ClassIsFinal;
+namespace Ergebnis\Test\Util\Test\Fixture\ClassIsFinal;
 
 class NeitherAbstractNorFinalClass
 {

--- a/test/Fixture/ClassSatisfiesSpecification/ExampleClass.php
+++ b/test/Fixture/ClassSatisfiesSpecification/ExampleClass.php
@@ -2,7 +2,7 @@
 
 declare(strict_types=1);
 
-namespace Localheinz\Test\Util\Test\Fixture\ClassSatisfiesSpecification;
+namespace Ergebnis\Test\Util\Test\Fixture\ClassSatisfiesSpecification;
 
 final class ExampleClass
 {

--- a/test/Fixture/ClassUsesTrait/ClassNotUsingTrait.php
+++ b/test/Fixture/ClassUsesTrait/ClassNotUsingTrait.php
@@ -2,7 +2,7 @@
 
 declare(strict_types=1);
 
-namespace Localheinz\Test\Util\Test\Fixture\ClassUsesTrait;
+namespace Ergebnis\Test\Util\Test\Fixture\ClassUsesTrait;
 
 final class ClassNotUsingTrait
 {

--- a/test/Fixture/ClassUsesTrait/ClassUsingTrait.php
+++ b/test/Fixture/ClassUsesTrait/ClassUsingTrait.php
@@ -2,7 +2,7 @@
 
 declare(strict_types=1);
 
-namespace Localheinz\Test\Util\Test\Fixture\ClassUsesTrait;
+namespace Ergebnis\Test\Util\Test\Fixture\ClassUsesTrait;
 
 final class ClassUsingTrait
 {

--- a/test/Fixture/ClassUsesTrait/ExampleTrait.php
+++ b/test/Fixture/ClassUsesTrait/ExampleTrait.php
@@ -2,7 +2,7 @@
 
 declare(strict_types=1);
 
-namespace Localheinz\Test\Util\Test\Fixture\ClassUsesTrait;
+namespace Ergebnis\Test\Util\Test\Fixture\ClassUsesTrait;
 
 trait ExampleTrait
 {

--- a/test/Fixture/ClassesAreAbstractOrFinal/AbstractClass.php
+++ b/test/Fixture/ClassesAreAbstractOrFinal/AbstractClass.php
@@ -2,7 +2,7 @@
 
 declare(strict_types=1);
 
-namespace Localheinz\Test\Util\Test\Fixture\ClassesAreAbstractOrFinal;
+namespace Ergebnis\Test\Util\Test\Fixture\ClassesAreAbstractOrFinal;
 
 final class AbstractClass
 {

--- a/test/Fixture/ClassesAreAbstractOrFinal/AbstractOrFinal/AbstractClass.php
+++ b/test/Fixture/ClassesAreAbstractOrFinal/AbstractOrFinal/AbstractClass.php
@@ -2,7 +2,7 @@
 
 declare(strict_types=1);
 
-namespace Localheinz\Test\Util\Test\Fixture\ClassesAreAbstractOrFinal\AbstractOrFinal;
+namespace Ergebnis\Test\Util\Test\Fixture\ClassesAreAbstractOrFinal\AbstractOrFinal;
 
 abstract class AbstractClass
 {

--- a/test/Fixture/ClassesAreAbstractOrFinal/AbstractOrFinal/FinalClass.php
+++ b/test/Fixture/ClassesAreAbstractOrFinal/AbstractOrFinal/FinalClass.php
@@ -2,7 +2,7 @@
 
 declare(strict_types=1);
 
-namespace Localheinz\Test\Util\Test\Fixture\ClassesAreAbstractOrFinal\AbstractOrFinal;
+namespace Ergebnis\Test\Util\Test\Fixture\ClassesAreAbstractOrFinal\AbstractOrFinal;
 
 final class FinalClass
 {

--- a/test/Fixture/ClassesAreAbstractOrFinal/FinalClass.php
+++ b/test/Fixture/ClassesAreAbstractOrFinal/FinalClass.php
@@ -2,7 +2,7 @@
 
 declare(strict_types=1);
 
-namespace Localheinz\Test\Util\Test\Fixture\ClassesAreAbstractOrFinal;
+namespace Ergebnis\Test\Util\Test\Fixture\ClassesAreAbstractOrFinal;
 
 final class FinalClass
 {

--- a/test/Fixture/ClassesAreAbstractOrFinal/NotAllAbstractOrFinal/AbstractClass.php
+++ b/test/Fixture/ClassesAreAbstractOrFinal/NotAllAbstractOrFinal/AbstractClass.php
@@ -2,7 +2,7 @@
 
 declare(strict_types=1);
 
-namespace Localheinz\Test\Util\Test\Fixture\ClassesAreAbstractOrFinal\NotAllAbstractOrFinal;
+namespace Ergebnis\Test\Util\Test\Fixture\ClassesAreAbstractOrFinal\NotAllAbstractOrFinal;
 
 abstract class AbstractClass
 {

--- a/test/Fixture/ClassesAreAbstractOrFinal/NotAllAbstractOrFinal/AlsoNeitherAbstractNorFinal.php
+++ b/test/Fixture/ClassesAreAbstractOrFinal/NotAllAbstractOrFinal/AlsoNeitherAbstractNorFinal.php
@@ -2,7 +2,7 @@
 
 declare(strict_types=1);
 
-namespace Localheinz\Test\Util\Test\Fixture\ClassesAreAbstractOrFinal\NotAllAbstractOrFinal;
+namespace Ergebnis\Test\Util\Test\Fixture\ClassesAreAbstractOrFinal\NotAllAbstractOrFinal;
 
 class AlsoNeitherAbstractNorFinal
 {

--- a/test/Fixture/ClassesAreAbstractOrFinal/NotAllAbstractOrFinal/FinalClass.php
+++ b/test/Fixture/ClassesAreAbstractOrFinal/NotAllAbstractOrFinal/FinalClass.php
@@ -2,7 +2,7 @@
 
 declare(strict_types=1);
 
-namespace Localheinz\Test\Util\Test\Fixture\ClassesAreAbstractOrFinal\NotAllAbstractOrFinal;
+namespace Ergebnis\Test\Util\Test\Fixture\ClassesAreAbstractOrFinal\NotAllAbstractOrFinal;
 
 final class FinalClass
 {

--- a/test/Fixture/ClassesAreAbstractOrFinal/NotAllAbstractOrFinal/NeitherAbstractNorFinal.php
+++ b/test/Fixture/ClassesAreAbstractOrFinal/NotAllAbstractOrFinal/NeitherAbstractNorFinal.php
@@ -2,7 +2,7 @@
 
 declare(strict_types=1);
 
-namespace Localheinz\Test\Util\Test\Fixture\ClassesAreAbstractOrFinal\NotAllAbstractOrFinal;
+namespace Ergebnis\Test\Util\Test\Fixture\ClassesAreAbstractOrFinal\NotAllAbstractOrFinal;
 
 class NeitherAbstractNorFinal
 {

--- a/test/Fixture/ClassesHaveTests/NotAllClassesHaveTests/Src/AnotherExampleClass.php
+++ b/test/Fixture/ClassesHaveTests/NotAllClassesHaveTests/Src/AnotherExampleClass.php
@@ -2,7 +2,7 @@
 
 declare(strict_types=1);
 
-namespace Localheinz\Test\Util\Test\Fixture\ClassesHaveTests\NotAllClassesHaveTests\Src;
+namespace Ergebnis\Test\Util\Test\Fixture\ClassesHaveTests\NotAllClassesHaveTests\Src;
 
 final class AnotherExampleClass
 {

--- a/test/Fixture/ClassesHaveTests/NotAllClassesHaveTests/Src/ExampleClass.php
+++ b/test/Fixture/ClassesHaveTests/NotAllClassesHaveTests/Src/ExampleClass.php
@@ -2,7 +2,7 @@
 
 declare(strict_types=1);
 
-namespace Localheinz\Test\Util\Test\Fixture\ClassesHaveTests\NotAllClassesHaveTests\Src;
+namespace Ergebnis\Test\Util\Test\Fixture\ClassesHaveTests\NotAllClassesHaveTests\Src;
 
 final class ExampleClass
 {

--- a/test/Fixture/ClassesHaveTests/NotAllClassesHaveTests/Src/OneMoreExampleClass.php
+++ b/test/Fixture/ClassesHaveTests/NotAllClassesHaveTests/Src/OneMoreExampleClass.php
@@ -2,7 +2,7 @@
 
 declare(strict_types=1);
 
-namespace Localheinz\Test\Util\Test\Fixture\ClassesHaveTests\NotAllClassesHaveTests\Src;
+namespace Ergebnis\Test\Util\Test\Fixture\ClassesHaveTests\NotAllClassesHaveTests\Src;
 
 final class OneMoreExampleClass
 {

--- a/test/Fixture/ClassesHaveTests/NotAllClassesHaveTests/Test/ExampleClassTest.php
+++ b/test/Fixture/ClassesHaveTests/NotAllClassesHaveTests/Test/ExampleClassTest.php
@@ -2,7 +2,7 @@
 
 declare(strict_types=1);
 
-namespace Localheinz\Test\Util\Test\Fixture\ClassesHaveTests\NotAllClassesHaveTests\Test;
+namespace Ergebnis\Test\Util\Test\Fixture\ClassesHaveTests\NotAllClassesHaveTests\Test;
 
 use PHPUnit\Framework;
 

--- a/test/Fixture/ClassesHaveTests/WithTests/Src/AbstractClass.php
+++ b/test/Fixture/ClassesHaveTests/WithTests/Src/AbstractClass.php
@@ -2,7 +2,7 @@
 
 declare(strict_types=1);
 
-namespace Localheinz\Test\Util\Test\Fixture\ClassesHaveTests\WithTests\Src;
+namespace Ergebnis\Test\Util\Test\Fixture\ClassesHaveTests\WithTests\Src;
 
 abstract class AbstractClass
 {

--- a/test/Fixture/ClassesHaveTests/WithTests/Src/ExampleClass.php
+++ b/test/Fixture/ClassesHaveTests/WithTests/Src/ExampleClass.php
@@ -2,7 +2,7 @@
 
 declare(strict_types=1);
 
-namespace Localheinz\Test\Util\Test\Fixture\ClassesHaveTests\WithTests\Src;
+namespace Ergebnis\Test\Util\Test\Fixture\ClassesHaveTests\WithTests\Src;
 
 final class ExampleClass
 {

--- a/test/Fixture/ClassesHaveTests/WithTests/Src/ExampleInterface.php
+++ b/test/Fixture/ClassesHaveTests/WithTests/Src/ExampleInterface.php
@@ -2,7 +2,7 @@
 
 declare(strict_types=1);
 
-namespace Localheinz\Test\Util\Test\Fixture\ClassesHaveTests\WithTests\Src;
+namespace Ergebnis\Test\Util\Test\Fixture\ClassesHaveTests\WithTests\Src;
 
 interface ExampleInterface
 {

--- a/test/Fixture/ClassesHaveTests/WithTests/Src/ExampleTest.php
+++ b/test/Fixture/ClassesHaveTests/WithTests/Src/ExampleTest.php
@@ -2,7 +2,7 @@
 
 declare(strict_types=1);
 
-namespace Localheinz\Test\Util\Test\Fixture\ClassesHaveTests\WithTests\Src;
+namespace Ergebnis\Test\Util\Test\Fixture\ClassesHaveTests\WithTests\Src;
 
 use PHPUnit\Framework;
 

--- a/test/Fixture/ClassesHaveTests/WithTests/Src/ExampleTrait.php
+++ b/test/Fixture/ClassesHaveTests/WithTests/Src/ExampleTrait.php
@@ -2,7 +2,7 @@
 
 declare(strict_types=1);
 
-namespace Localheinz\Test\Util\Test\Fixture\ClassesHaveTests\WithTests\Src;
+namespace Ergebnis\Test\Util\Test\Fixture\ClassesHaveTests\WithTests\Src;
 
 trait ExampleTrait
 {

--- a/test/Fixture/ClassesHaveTests/WithTests/Test/ExampleClassTest.php
+++ b/test/Fixture/ClassesHaveTests/WithTests/Test/ExampleClassTest.php
@@ -2,7 +2,7 @@
 
 declare(strict_types=1);
 
-namespace Localheinz\Test\Util\Test\Fixture\ClassesHaveTests\WithTests\Test;
+namespace Ergebnis\Test\Util\Test\Fixture\ClassesHaveTests\WithTests\Test;
 
 use PHPUnit\Framework;
 

--- a/test/Fixture/ClassesHaveTests/WithoutTests/Src/AbstractClass.php
+++ b/test/Fixture/ClassesHaveTests/WithoutTests/Src/AbstractClass.php
@@ -2,7 +2,7 @@
 
 declare(strict_types=1);
 
-namespace Localheinz\Test\Util\Test\Fixture\ClassesHaveTests\WithoutTests\Src;
+namespace Ergebnis\Test\Util\Test\Fixture\ClassesHaveTests\WithoutTests\Src;
 
 abstract class AbstractClass
 {

--- a/test/Fixture/ClassesHaveTests/WithoutTests/Src/AnotherExampleClass.php
+++ b/test/Fixture/ClassesHaveTests/WithoutTests/Src/AnotherExampleClass.php
@@ -2,7 +2,7 @@
 
 declare(strict_types=1);
 
-namespace Localheinz\Test\Util\Test\Fixture\ClassesHaveTests\WithoutTests\Src;
+namespace Ergebnis\Test\Util\Test\Fixture\ClassesHaveTests\WithoutTests\Src;
 
 final class AnotherExampleClass
 {

--- a/test/Fixture/ClassesHaveTests/WithoutTests/Src/ExampleClass.php
+++ b/test/Fixture/ClassesHaveTests/WithoutTests/Src/ExampleClass.php
@@ -2,7 +2,7 @@
 
 declare(strict_types=1);
 
-namespace Localheinz\Test\Util\Test\Fixture\ClassesHaveTests\WithoutTests\Src;
+namespace Ergebnis\Test\Util\Test\Fixture\ClassesHaveTests\WithoutTests\Src;
 
 final class ExampleClass
 {

--- a/test/Fixture/ClassesHaveTests/WithoutTests/Src/ExampleInterface.php
+++ b/test/Fixture/ClassesHaveTests/WithoutTests/Src/ExampleInterface.php
@@ -2,7 +2,7 @@
 
 declare(strict_types=1);
 
-namespace Localheinz\Test\Util\Test\Fixture\ClassesHaveTests\WithoutTests\Src;
+namespace Ergebnis\Test\Util\Test\Fixture\ClassesHaveTests\WithoutTests\Src;
 
 interface ExampleInterface
 {

--- a/test/Fixture/ClassesHaveTests/WithoutTests/Src/ExampleTrait.php
+++ b/test/Fixture/ClassesHaveTests/WithoutTests/Src/ExampleTrait.php
@@ -2,7 +2,7 @@
 
 declare(strict_types=1);
 
-namespace Localheinz\Test\Util\Test\Fixture\ClassesHaveTests\WithoutTests\Src;
+namespace Ergebnis\Test\Util\Test\Fixture\ClassesHaveTests\WithoutTests\Src;
 
 trait ExampleTrait
 {

--- a/test/Fixture/ClassesHaveTests/WithoutTests/Src/OneMoreExampleClass.php
+++ b/test/Fixture/ClassesHaveTests/WithoutTests/Src/OneMoreExampleClass.php
@@ -2,7 +2,7 @@
 
 declare(strict_types=1);
 
-namespace Localheinz\Test\Util\Test\Fixture\ClassesHaveTests\WithoutTests\Src;
+namespace Ergebnis\Test\Util\Test\Fixture\ClassesHaveTests\WithoutTests\Src;
 
 final class OneMoreExampleClass
 {

--- a/test/Fixture/ClassesHaveTests/WithoutTests/Src/YetAnotherExampleClass.php
+++ b/test/Fixture/ClassesHaveTests/WithoutTests/Src/YetAnotherExampleClass.php
@@ -2,7 +2,7 @@
 
 declare(strict_types=1);
 
-namespace Localheinz\Test\Util\Test\Fixture\ClassesHaveTests\WithoutTests\Src;
+namespace Ergebnis\Test\Util\Test\Fixture\ClassesHaveTests\WithoutTests\Src;
 
 final class YetAnotherExampleClass
 {

--- a/test/Fixture/ClassesHaveTests/WithoutTests/Test/AnotherExampleClassTest.php
+++ b/test/Fixture/ClassesHaveTests/WithoutTests/Test/AnotherExampleClassTest.php
@@ -2,7 +2,7 @@
 
 declare(strict_types=1);
 
-namespace Localheinz\Test\Util\Test\Fixture\ClassesHaveTests\WithoutTests\Test;
+namespace Ergebnis\Test\Util\Test\Fixture\ClassesHaveTests\WithoutTests\Test;
 
 /**
  * Does not extend from PHPUnit\Framework\TestCase.

--- a/test/Fixture/ClassesHaveTests/WithoutTests/Test/OneMoreExampleClassTest.php
+++ b/test/Fixture/ClassesHaveTests/WithoutTests/Test/OneMoreExampleClassTest.php
@@ -2,7 +2,7 @@
 
 declare(strict_types=1);
 
-namespace Localheinz\Test\Util\Test\Fixture\ClassesHaveTests\WithoutTests\Test;
+namespace Ergebnis\Test\Util\Test\Fixture\ClassesHaveTests\WithoutTests\Test;
 
 use PHPUnit\Framework;
 

--- a/test/Fixture/ClassyConstructsSatisfySpecification/AnotherExampleClass.php
+++ b/test/Fixture/ClassyConstructsSatisfySpecification/AnotherExampleClass.php
@@ -2,7 +2,7 @@
 
 declare(strict_types=1);
 
-namespace Localheinz\Test\Util\Test\Fixture\ClassyConstructsSatisfySpecification;
+namespace Ergebnis\Test\Util\Test\Fixture\ClassyConstructsSatisfySpecification;
 
 final class AnotherExampleClass
 {

--- a/test/Fixture/ClassyConstructsSatisfySpecification/ExampleClass.php
+++ b/test/Fixture/ClassyConstructsSatisfySpecification/ExampleClass.php
@@ -2,7 +2,7 @@
 
 declare(strict_types=1);
 
-namespace Localheinz\Test\Util\Test\Fixture\ClassyConstructsSatisfySpecification;
+namespace Ergebnis\Test\Util\Test\Fixture\ClassyConstructsSatisfySpecification;
 
 final class ExampleClass
 {

--- a/test/Fixture/ImplementsInterface/ClassImplementingInterface.php
+++ b/test/Fixture/ImplementsInterface/ClassImplementingInterface.php
@@ -2,7 +2,7 @@
 
 declare(strict_types=1);
 
-namespace Localheinz\Test\Util\Test\Fixture\ImplementsInterface;
+namespace Ergebnis\Test\Util\Test\Fixture\ImplementsInterface;
 
 final class ClassImplementingInterface implements ExampleInterface
 {

--- a/test/Fixture/ImplementsInterface/ClassNotImplementingInterface.php
+++ b/test/Fixture/ImplementsInterface/ClassNotImplementingInterface.php
@@ -2,7 +2,7 @@
 
 declare(strict_types=1);
 
-namespace Localheinz\Test\Util\Test\Fixture\ImplementsInterface;
+namespace Ergebnis\Test\Util\Test\Fixture\ImplementsInterface;
 
 final class ClassNotImplementingInterface
 {

--- a/test/Fixture/ImplementsInterface/ExampleInterface.php
+++ b/test/Fixture/ImplementsInterface/ExampleInterface.php
@@ -2,7 +2,7 @@
 
 declare(strict_types=1);
 
-namespace Localheinz\Test\Util\Test\Fixture\ImplementsInterface;
+namespace Ergebnis\Test\Util\Test\Fixture\ImplementsInterface;
 
 interface ExampleInterface
 {

--- a/test/Fixture/InterfaceExists/ExampleInterface.php
+++ b/test/Fixture/InterfaceExists/ExampleInterface.php
@@ -2,7 +2,7 @@
 
 declare(strict_types=1);
 
-namespace Localheinz\Test\Util\Test\Fixture\InterfaceExists;
+namespace Ergebnis\Test\Util\Test\Fixture\InterfaceExists;
 
 interface ExampleInterface
 {

--- a/test/Fixture/InterfaceExtends/ChildInterface.php
+++ b/test/Fixture/InterfaceExtends/ChildInterface.php
@@ -2,7 +2,7 @@
 
 declare(strict_types=1);
 
-namespace Localheinz\Test\Util\Test\Fixture\InterfaceExtends;
+namespace Ergebnis\Test\Util\Test\Fixture\InterfaceExtends;
 
 interface ChildInterface extends ParentInterface
 {

--- a/test/Fixture/InterfaceExtends/ParentInterface.php
+++ b/test/Fixture/InterfaceExtends/ParentInterface.php
@@ -2,7 +2,7 @@
 
 declare(strict_types=1);
 
-namespace Localheinz\Test\Util\Test\Fixture\InterfaceExtends;
+namespace Ergebnis\Test\Util\Test\Fixture\InterfaceExtends;
 
 interface ParentInterface
 {

--- a/test/Fixture/InterfaceExtends/UnrelatedInterface.php
+++ b/test/Fixture/InterfaceExtends/UnrelatedInterface.php
@@ -2,7 +2,7 @@
 
 declare(strict_types=1);
 
-namespace Localheinz\Test\Util\Test\Fixture\InterfaceExtends;
+namespace Ergebnis\Test\Util\Test\Fixture\InterfaceExtends;
 
 interface UnrelatedInterface
 {

--- a/test/Fixture/InterfaceSatisfiesSpecification/ExampleInterface.php
+++ b/test/Fixture/InterfaceSatisfiesSpecification/ExampleInterface.php
@@ -2,7 +2,7 @@
 
 declare(strict_types=1);
 
-namespace Localheinz\Test\Util\Test\Fixture\InterfaceSatisfiesSpecification;
+namespace Ergebnis\Test\Util\Test\Fixture\InterfaceSatisfiesSpecification;
 
 interface ExampleInterface
 {

--- a/test/Fixture/NotClass/ExampleInterface.php
+++ b/test/Fixture/NotClass/ExampleInterface.php
@@ -2,7 +2,7 @@
 
 declare(strict_types=1);
 
-namespace Localheinz\Test\Util\Test\Fixture\NotClass;
+namespace Ergebnis\Test\Util\Test\Fixture\NotClass;
 
 interface ExampleInterface
 {

--- a/test/Fixture/NotClass/ExampleTrait.php
+++ b/test/Fixture/NotClass/ExampleTrait.php
@@ -2,7 +2,7 @@
 
 declare(strict_types=1);
 
-namespace Localheinz\Test\Util\Test\Fixture\NotClass;
+namespace Ergebnis\Test\Util\Test\Fixture\NotClass;
 
 trait ExampleTrait
 {

--- a/test/Fixture/NotInterface/ExampleClass.php
+++ b/test/Fixture/NotInterface/ExampleClass.php
@@ -2,7 +2,7 @@
 
 declare(strict_types=1);
 
-namespace Localheinz\Test\Util\Test\Fixture\NotInterface;
+namespace Ergebnis\Test\Util\Test\Fixture\NotInterface;
 
 final class ExampleClass
 {

--- a/test/Fixture/NotInterface/ExampleTrait.php
+++ b/test/Fixture/NotInterface/ExampleTrait.php
@@ -2,7 +2,7 @@
 
 declare(strict_types=1);
 
-namespace Localheinz\Test\Util\Test\Fixture\NotInterface;
+namespace Ergebnis\Test\Util\Test\Fixture\NotInterface;
 
 trait ExampleTrait
 {

--- a/test/Fixture/NotTrait/ExampleClass.php
+++ b/test/Fixture/NotTrait/ExampleClass.php
@@ -2,7 +2,7 @@
 
 declare(strict_types=1);
 
-namespace Localheinz\Test\Util\Test\Fixture\NotTrait;
+namespace Ergebnis\Test\Util\Test\Fixture\NotTrait;
 
 final class ExampleClass
 {

--- a/test/Fixture/NotTrait/ExampleInterface.php
+++ b/test/Fixture/NotTrait/ExampleInterface.php
@@ -2,7 +2,7 @@
 
 declare(strict_types=1);
 
-namespace Localheinz\Test\Util\Test\Fixture\NotTrait;
+namespace Ergebnis\Test\Util\Test\Fixture\NotTrait;
 
 interface ExampleInterface
 {

--- a/test/Fixture/TraitExists/ExampleTrait.php
+++ b/test/Fixture/TraitExists/ExampleTrait.php
@@ -2,7 +2,7 @@
 
 declare(strict_types=1);
 
-namespace Localheinz\Test\Util\Test\Fixture\TraitExists;
+namespace Ergebnis\Test\Util\Test\Fixture\TraitExists;
 
 trait ExampleTrait
 {

--- a/test/Fixture/TraitSatisfiesSpecification/ExampleTrait.php
+++ b/test/Fixture/TraitSatisfiesSpecification/ExampleTrait.php
@@ -2,7 +2,7 @@
 
 declare(strict_types=1);
 
-namespace Localheinz\Test\Util\Test\Fixture\TraitSatisfiesSpecification;
+namespace Ergebnis\Test\Util\Test\Fixture\TraitSatisfiesSpecification;
 
 trait ExampleTrait
 {

--- a/test/Unit/Exception/InvalidExcludeClassNameTest.php
+++ b/test/Unit/Exception/InvalidExcludeClassNameTest.php
@@ -11,18 +11,18 @@ declare(strict_types=1);
  * @see https://github.com/ergebnis/test-util
  */
 
-namespace Localheinz\Test\Util\Test\Unit\Exception;
+namespace Ergebnis\Test\Util\Test\Unit\Exception;
 
-use Localheinz\Test\Util\Exception\InvalidExcludeClassName;
-use Localheinz\Test\Util\Helper;
+use Ergebnis\Test\Util\Exception\InvalidExcludeClassName;
+use Ergebnis\Test\Util\Helper;
 use PHPUnit\Framework;
 
 /**
  * @internal
  *
- * @covers \Localheinz\Test\Util\Exception\InvalidExcludeClassName
+ * @covers \Ergebnis\Test\Util\Exception\InvalidExcludeClassName
  *
- * @uses \Localheinz\Test\Util\Helper
+ * @uses \Ergebnis\Test\Util\Helper
  */
 final class InvalidExcludeClassNameTest extends Framework\TestCase
 {

--- a/test/Unit/Exception/NonExistentDirectoryTest.php
+++ b/test/Unit/Exception/NonExistentDirectoryTest.php
@@ -11,18 +11,18 @@ declare(strict_types=1);
  * @see https://github.com/ergebnis/test-util
  */
 
-namespace Localheinz\Test\Util\Test\Unit\Exception;
+namespace Ergebnis\Test\Util\Test\Unit\Exception;
 
-use Localheinz\Test\Util\Exception\NonExistentDirectory;
-use Localheinz\Test\Util\Helper;
+use Ergebnis\Test\Util\Exception\NonExistentDirectory;
+use Ergebnis\Test\Util\Helper;
 use PHPUnit\Framework;
 
 /**
  * @internal
  *
- * @covers \Localheinz\Test\Util\Exception\NonExistentDirectory
+ * @covers \Ergebnis\Test\Util\Exception\NonExistentDirectory
  *
- * @uses \Localheinz\Test\Util\Helper
+ * @uses \Ergebnis\Test\Util\Helper
  */
 final class NonExistentDirectoryTest extends Framework\TestCase
 {

--- a/test/Unit/Exception/NonExistentExcludeClassTest.php
+++ b/test/Unit/Exception/NonExistentExcludeClassTest.php
@@ -11,18 +11,18 @@ declare(strict_types=1);
  * @see https://github.com/ergebnis/test-util
  */
 
-namespace Localheinz\Test\Util\Test\Unit\Exception;
+namespace Ergebnis\Test\Util\Test\Unit\Exception;
 
-use Localheinz\Test\Util\Exception\NonExistentExcludeClass;
-use Localheinz\Test\Util\Helper;
+use Ergebnis\Test\Util\Exception\NonExistentExcludeClass;
+use Ergebnis\Test\Util\Helper;
 use PHPUnit\Framework;
 
 /**
  * @internal
  *
- * @covers \Localheinz\Test\Util\Exception\NonExistentExcludeClass
+ * @covers \Ergebnis\Test\Util\Exception\NonExistentExcludeClass
  *
- * @uses \Localheinz\Test\Util\Helper
+ * @uses \Ergebnis\Test\Util\Helper
  */
 final class NonExistentExcludeClassTest extends Framework\TestCase
 {

--- a/test/Unit/HelperTest.php
+++ b/test/Unit/HelperTest.php
@@ -11,24 +11,24 @@ declare(strict_types=1);
  * @see https://github.com/ergebnis/test-util
  */
 
-namespace Localheinz\Test\Util\Test\Unit;
+namespace Ergebnis\Test\Util\Test\Unit;
 
+use Ergebnis\Test\Util\Exception;
+use Ergebnis\Test\Util\Helper;
+use Ergebnis\Test\Util\Test\Fixture;
 use Faker\Factory;
 use Faker\Generator;
 use Faker\Provider;
-use Localheinz\Test\Util\Exception;
-use Localheinz\Test\Util\Helper;
-use Localheinz\Test\Util\Test\Fixture;
 use PHPUnit\Framework;
 
 /**
  * @internal
  *
- * @covers \Localheinz\Test\Util\Helper
+ * @covers \Ergebnis\Test\Util\Helper
  *
- * @uses \Localheinz\Test\Util\Exception\InvalidExcludeClassName
- * @uses \Localheinz\Test\Util\Exception\NonExistentDirectory
- * @uses \Localheinz\Test\Util\Exception\NonExistentExcludeClass
+ * @uses \Ergebnis\Test\Util\Exception\InvalidExcludeClassName
+ * @uses \Ergebnis\Test\Util\Exception\NonExistentDirectory
+ * @uses \Ergebnis\Test\Util\Exception\NonExistentExcludeClass
  */
 final class HelperTest extends Framework\TestCase
 {
@@ -269,8 +269,8 @@ final class HelperTest extends Framework\TestCase
     public function testAssertClassesHaveTestsFailsWhenFoundClassesDoNotHaveTests(): void
     {
         $directory = __DIR__ . '/../Fixture/ClassesHaveTests/WithoutTests/Src';
-        $namespace = 'Localheinz\\Test\\Util\\Test\\Fixture\\ClassesHaveTests\\WithoutTests\\Src\\';
-        $testNamespace = 'Localheinz\\Test\\Util\\Test\\Fixture\\ClassesHaveTests\\WithoutTests\\Test\\';
+        $namespace = 'Ergebnis\\Test\\Util\\Test\\Fixture\\ClassesHaveTests\\WithoutTests\\Src\\';
+        $testNamespace = 'Ergebnis\\Test\\Util\\Test\\Fixture\\ClassesHaveTests\\WithoutTests\\Test\\';
 
         $classesWithoutTests = [
             Fixture\ClassesHaveTests\WithoutTests\Src\AnotherExampleClass::class,
@@ -313,8 +313,8 @@ final class HelperTest extends Framework\TestCase
     public function testAssertClassesHaveTestsSucceedsWhenNoClassesHaveBeenFound(): void
     {
         $directory = __DIR__ . '/../Fixture/ClassesHaveTests/EmptyDirectory/Src';
-        $namespace = 'Localheinz\\Test\\Util\\Test\\Fixture\\ClassesHaveTests\\EmptyDirectory\\Src\\';
-        $testNamespace = 'Localheinz\\Test\\Util\\Test\\Fixture\\ClassesHaveTests\\EmptyDirectory\\Test\\';
+        $namespace = 'Ergebnis\\Test\\Util\\Test\\Fixture\\ClassesHaveTests\\EmptyDirectory\\Src\\';
+        $testNamespace = 'Ergebnis\\Test\\Util\\Test\\Fixture\\ClassesHaveTests\\EmptyDirectory\\Test\\';
 
         self::assertClassesHaveTests(
             $directory,
@@ -326,8 +326,8 @@ final class HelperTest extends Framework\TestCase
     public function testAssertClassesHaveTestsSucceedsWhenFoundClassesHaveTests(): void
     {
         $directory = __DIR__ . '/../Fixture/ClassesHaveTests/WithTests/Src';
-        $namespace = 'Localheinz\\Test\\Util\\Test\\Fixture\\ClassesHaveTests\\WithTests\\Src\\';
-        $testNamespace = 'Localheinz\\Test\\Util\\Test\\Fixture\\ClassesHaveTests\\WithTests\\Test\\';
+        $namespace = 'Ergebnis\\Test\\Util\\Test\\Fixture\\ClassesHaveTests\\WithTests\\Src\\';
+        $testNamespace = 'Ergebnis\\Test\\Util\\Test\\Fixture\\ClassesHaveTests\\WithTests\\Test\\';
 
         self::assertClassesHaveTests(
             $directory,
@@ -356,13 +356,13 @@ final class HelperTest extends Framework\TestCase
     public function providerNamespaceAndTestNamespace(): \Generator
     {
         $namespaces = [
-            'Localheinz\\Test\\Util\\Test\\Fixture\\ClassesHaveTests\\WithTests\\Src',
-            'Localheinz\\Test\\Util\\Test\\Fixture\\ClassesHaveTests\\WithTests\\Src\\',
+            'Ergebnis\\Test\\Util\\Test\\Fixture\\ClassesHaveTests\\WithTests\\Src',
+            'Ergebnis\\Test\\Util\\Test\\Fixture\\ClassesHaveTests\\WithTests\\Src\\',
         ];
 
         $testNamespaces = [
-            'Localheinz\\Test\\Util\\Test\\Fixture\\ClassesHaveTests\\WithTests\\Test',
-            'Localheinz\\Test\\Util\\Test\\Fixture\\ClassesHaveTests\\WithTests\\Test\\',
+            'Ergebnis\\Test\\Util\\Test\\Fixture\\ClassesHaveTests\\WithTests\\Test',
+            'Ergebnis\\Test\\Util\\Test\\Fixture\\ClassesHaveTests\\WithTests\\Test\\',
         ];
 
         foreach ($namespaces as $namespace) {
@@ -383,8 +383,8 @@ final class HelperTest extends Framework\TestCase
     public function testAssertClassesHaveTestsWithExcludeClassNamesRejectsInvalidExcludeClassNames($excludeClassyName): void
     {
         $directory = __DIR__ . '/../Fixture/ClassesHaveTests/NotAllClassesHaveTests/Src';
-        $namespace = 'Localheinz\\Test\\Util\\Test\\Fixture\\ClassesHaveTests\\NotAllClassesHaveTests\\Src\\';
-        $testNamespace = 'Localheinz\\Test\\Util\\Test\\Fixture\\ClassesHaveTests\\NotAllClassesHaveTests\\Test\\';
+        $namespace = 'Ergebnis\\Test\\Util\\Test\\Fixture\\ClassesHaveTests\\NotAllClassesHaveTests\\Src\\';
+        $testNamespace = 'Ergebnis\\Test\\Util\\Test\\Fixture\\ClassesHaveTests\\NotAllClassesHaveTests\\Test\\';
         $excludeClassyNames = [
             $excludeClassyName,
         ];
@@ -402,8 +402,8 @@ final class HelperTest extends Framework\TestCase
     public function testAssertClassesHaveTestsWithExcludeClassNamesRejectsNonExistentExcludeClassNames(): void
     {
         $directory = __DIR__ . '/../Fixture/ClassesHaveTests/NotAllClassesHaveTests/Src';
-        $namespace = 'Localheinz\\Test\\Util\\Test\\Fixture\\ClassesHaveTests\\NotAllClassesHaveTests\\Src\\';
-        $testNamespace = 'Localheinz\\Test\\Util\\Test\\Fixture\\ClassesHaveTests\\NotAllClassesHaveTests\\Test\\';
+        $namespace = 'Ergebnis\\Test\\Util\\Test\\Fixture\\ClassesHaveTests\\NotAllClassesHaveTests\\Src\\';
+        $testNamespace = 'Ergebnis\\Test\\Util\\Test\\Fixture\\ClassesHaveTests\\NotAllClassesHaveTests\\Test\\';
         $nonExistentClassName = __NAMESPACE__ . '\\NonExistentClass';
         $excludeClassyNames = [
             Fixture\ClassesHaveTests\NotAllClassesHaveTests\Src\AnotherExampleClass::class,
@@ -424,8 +424,8 @@ final class HelperTest extends Framework\TestCase
     public function testAssertClassesHaveTestsWithExcludeClassNamesFailsWhenFoundClassesDoNotHaveTests(): void
     {
         $directory = __DIR__ . '/../Fixture/ClassesHaveTests/NotAllClassesHaveTests/Src';
-        $namespace = 'Localheinz\\Test\\Util\\Test\\Fixture\\ClassesHaveTests\\NotAllClassesHaveTests\\Src\\';
-        $testNamespace = 'Localheinz\\Test\\Util\\Test\\Fixture\\ClassesHaveTests\\NotAllClassesHaveTests\\Test\\';
+        $namespace = 'Ergebnis\\Test\\Util\\Test\\Fixture\\ClassesHaveTests\\NotAllClassesHaveTests\\Src\\';
+        $testNamespace = 'Ergebnis\\Test\\Util\\Test\\Fixture\\ClassesHaveTests\\NotAllClassesHaveTests\\Test\\';
         $excludeClassyNames = [
             Fixture\ClassesHaveTests\NotAllClassesHaveTests\Src\AnotherExampleClass::class,
         ];
@@ -451,8 +451,8 @@ final class HelperTest extends Framework\TestCase
     public function testAssertClassesHaveTestsWithExcludeClassNamesSucceedsWhenFoundClassesHaveTests(): void
     {
         $directory = __DIR__ . '/../Fixture/ClassesHaveTests/NotAllClassesHaveTests/Src';
-        $namespace = 'Localheinz\\Test\\Util\\Test\\Fixture\\ClassesHaveTests\\NotAllClassesHaveTests\\Src\\';
-        $testNamespace = 'Localheinz\\Test\\Util\\Test\\Fixture\\ClassesHaveTests\\NotAllClassesHaveTests\\Test\\';
+        $namespace = 'Ergebnis\\Test\\Util\\Test\\Fixture\\ClassesHaveTests\\NotAllClassesHaveTests\\Src\\';
+        $testNamespace = 'Ergebnis\\Test\\Util\\Test\\Fixture\\ClassesHaveTests\\NotAllClassesHaveTests\\Test\\';
         $excludeClassyNames = [
             Fixture\ClassesHaveTests\NotAllClassesHaveTests\Src\AnotherExampleClass::class,
             Fixture\ClassesHaveTests\NotAllClassesHaveTests\Src\OneMoreExampleClass::class,


### PR DESCRIPTION
This PR

* [x] renames the vendor namespace `Localheinz` to `Ergebnis` after the move to @ergebnis