### PR TITLE
Fix: Use caret operator

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,7 +6,11 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 
 ## Unreleased
 
-For a full diff see [`0.9.1...master`][0.9.1...master].
+For a full diff see [`1.0.0...master`][1.0.0...master].
+
+## [`1.0.0`][1.0.0]
+
+For a full diff see [`0.9.1...1.0.0`][0.9.1...1.0.0].
 
 ## [`0.9.1`][0.9.1]
 
@@ -68,11 +72,13 @@ For a full diff see [`0.7.0...0.8.0`][0.7.0...0.8.0].
 [0.8.0]: https://github.com/ergebnis/test-util/releases/tag/0.8.0
 [0.9.0]: https://github.com/ergebnis/test-util/releases/tag/0.9.0
 [0.9.1]: https://github.com/ergebnis/test-util/releases/tag/0.9.1
+[1.0.0]: https://github.com/ergebnis/test-util/releases/tag/1.0.0
 
 [0.7.0...0.8.0]: https://github.com/ergebnis/test-util/compare/0.7.0...0.8.0
 [0.8.0...0.9.0]: https://github.com/ergebnis/test-util/compare/0.8.0...0.9.0
 [0.9.0...0.9.1]: https://github.com/ergebnis/test-util/compare/0.9.0...0.9.1
-[0.9.1...master]: https://github.com/ergebnis/test-util/compare/0.9.1...master
+[0.9.1...1.0.0]: https://github.com/ergebnis/test-util/compare/0.9.1...1.0.0
+[1.0.0...master]: https://github.com/ergebnis/test-util/compare/1.0.0...master
 
 [#118]: https://github.com/ergebnis/test-util/pull/118
 [#119]: https://github.com/ergebnis/test-util/pull/119

--- a/composer.json
+++ b/composer.json
@@ -18,7 +18,7 @@
   ],
   "require": {
     "php": "^7.1",
-    "ergebnis/classy": "~1.0.0",
+    "ergebnis/classy": "^1.0.0",
     "fzaninotto/faker": "^1.9.0"
   },
   "require-dev": {

--- a/composer.lock
+++ b/composer.lock
@@ -4,7 +4,7 @@
         "Read more about it at https://getcomposer.org/doc/01-basic-usage.md#installing-dependencies",
         "This file is @generated automatically"
     ],
-    "content-hash": "29f1bdb9eb55d47d48e4a38814668325",
+    "content-hash": "032232539b8f188b50959aebac2f04f5",
     "packages": [
         {
             "name": "ergebnis/classy",


### PR DESCRIPTION
This PR

* [x] uses the `^` operator when requiring `ergebnis/classy`