### PR TITLE
Fix: Drop support for PHP 7.1

### DIFF
--- a/.github/settings.yml
+++ b/.github/settings.yml
@@ -15,13 +15,10 @@ branches:
       required_status_checks:
         contexts:
           - "Code Coverage (7.4, locked)"
-          - "Coding Standards (7.1, locked)"
+          - "Coding Standards (7.2, locked)"
           - "Dependency Analysis (7.4, locked)"
           - "Mutation Tests (7.4, locked)"
           - "Static Code Analysis (7.4, locked)"
-          - "Tests (7.1, highest)"
-          - "Tests (7.1, locked)"
-          - "Tests (7.1, lowest)"
           - "Tests (7.2, highest)"
           - "Tests (7.2, locked)"
           - "Tests (7.2, lowest)"

--- a/.github/workflows/integrate.yaml
+++ b/.github/workflows/integrate.yaml
@@ -23,7 +23,7 @@ jobs:
     strategy:
       matrix:
         php-version:
-          - "7.1"
+          - "7.2"
 
         dependencies:
           - "locked"
@@ -198,7 +198,6 @@ jobs:
     strategy:
       matrix:
         php-version:
-          - "7.1"
           - "7.2"
           - "7.3"
           - "7.4"

--- a/.github/workflows/renew.yaml
+++ b/.github/workflows/renew.yaml
@@ -20,7 +20,7 @@ jobs:
     strategy:
       matrix:
         php-version:
-          - "7.1"
+          - "7.2"
 
         dependencies:
           - "locked"

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,7 +6,15 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 
 ## Unreleased
 
-For a full diff see [`1.0.0...main`][1.0.0...main].
+For a full diff see [`1.0.1...main`][1.0.1...main].
+
+## [`1.0.1`][1.0.1]
+
+For a full diff see [`1.0.0...1.0.1`][1.0.0...1.0.1].
+
+### Changed
+
+* Dropped support for PHP 7.1 ([#295]), by [@localheinz]
 
 ## [`1.0.0`][1.0.0]
 
@@ -73,12 +81,14 @@ For a full diff see [`0.7.0...0.8.0`][0.7.0...0.8.0].
 [0.9.0]: https://github.com/ergebnis/test-util/releases/tag/0.9.0
 [0.9.1]: https://github.com/ergebnis/test-util/releases/tag/0.9.1
 [1.0.0]: https://github.com/ergebnis/test-util/releases/tag/1.0.0
+[1.0.1]: https://github.com/ergebnis/test-util/releases/tag/1.0.1
 
 [0.7.0...0.8.0]: https://github.com/ergebnis/test-util/compare/0.7.0...0.8.0
 [0.8.0...0.9.0]: https://github.com/ergebnis/test-util/compare/0.8.0...0.9.0
 [0.9.0...0.9.1]: https://github.com/ergebnis/test-util/compare/0.9.0...0.9.1
 [0.9.1...1.0.0]: https://github.com/ergebnis/test-util/compare/0.9.1...1.0.0
-[1.0.0...main]: https://github.com/ergebnis/test-util/compare/1.0.0...main
+[1.0.0...1.0.1]: https://github.com/ergebnis/test-util/compare/1.0.0...1.0.1
+[1.0.1...main]: https://github.com/ergebnis/test-util/compare/1.0.1...main
 
 [#118]: https://github.com/ergebnis/test-util/pull/118
 [#119]: https://github.com/ergebnis/test-util/pull/119
@@ -86,6 +96,7 @@ For a full diff see [`0.7.0...0.8.0`][0.7.0...0.8.0].
 [#122]: https://github.com/ergebnis/test-util/pull/122
 [#147]: https://github.com/ergebnis/test-util/pull/147
 [#155]: https://github.com/ergebnis/test-util/pull/155
+[#295]: https://github.com/ergebnis/test-util/pull/295
 
 [@ergebnis]: https://github.com/ergebnis
 [@localheinz]: https://github.com/localheinz

--- a/composer.json
+++ b/composer.json
@@ -17,7 +17,7 @@
     }
   ],
   "require": {
-    "php": "^7.1",
+    "php": "^7.2",
     "ergebnis/classy": "^1.0.0",
     "fzaninotto/faker": "^1.9.0"
   },
@@ -38,7 +38,7 @@
   },
   "config": {
     "platform": {
-      "php": "7.1.33"
+      "php": "7.2.33"
     },
     "preferred-install": "dist",
     "sort-packages": true

--- a/composer.lock
+++ b/composer.lock
@@ -4,7 +4,7 @@
         "Read more about it at https://getcomposer.org/doc/01-basic-usage.md#installing-dependencies",
         "This file is @generated automatically"
     ],
-    "content-hash": "9020d34c21c1d808c17ae7ea40db6933",
+    "content-hash": "fd8feb1635c7ad18392fd1908bce4dd4",
     "packages": [
         {
             "name": "ergebnis/classy",
@@ -5068,11 +5068,11 @@
     "prefer-stable": false,
     "prefer-lowest": false,
     "platform": {
-        "php": "^7.1"
+        "php": "^7.2"
     },
     "platform-dev": [],
     "platform-overrides": {
-        "php": "7.1.33"
+        "php": "7.2.33"
     },
     "plugin-api-version": "1.1.0"
 }


### PR DESCRIPTION
This PR

* [x] drops support for PHP 7.1

Related to https://github.com/ergebnis/composer-normalize/issues/529.