### PR TITLE
Enhancement: Provide example for composition of data providers

### DIFF
--- a/README.md
+++ b/README.md
@@ -104,6 +104,35 @@ This package provides the following generic data providers:
 * [`Ergebnis\Test\Util\DataProvider\BooleanProvider`](https://github.com/ergebnis/test-util#dataproviderbooleanprovider)
 * [`Ergebnis\Test\Util\DataProvider\NullProvider`](https://github.com/ergebnis/test-util#dataprovidernullprovider)
 
+Since it is possible to use multiple `@dataProvider` annotations for test methods, these generic data providers allow for reuse and composition of data providers:
+
+```php
+<?php
+
+declare(strict_types=1);
+
+namespace Example\Test;
+
+use PHPUnit\Framework;
+
+final class ExampleTest extends Framework\TestCase
+{
+    /**
+     * @dataProvider \Ergebnis\Test\Util\DataProvider\StringProvider::blank()
+     * @dataProvider \Ergebnis\Test\Util\DataProvider\StringProvider::empty()
+     *
+     * @param string $value
+     */
+    public function testFromNameRejectsBlankOrEmptyStrings(string $value): void
+    {
+        $this->expectException(\InvalidArgumentException::class);
+        $this->expectExceptionMessage('Value can not be an empty or blank string.');
+
+        UserName::fromString($value);
+    }
+}
+```
+
 #### `DataProvider\BooleanProvider`
 
 * `arbitrary()` provides `true`, `false`


### PR DESCRIPTION
This PR

* [x] provides an example for the composition of data providers using multiple `@dataProvider` annotations

Follows #326.