### PR TITLE
Fix: Add StringProvider to list in README.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -103,6 +103,7 @@ This package provides the following generic data providers:
 
 * [`Ergebnis\Test\Util\DataProvider\BooleanProvider`](https://github.com/ergebnis/test-util#dataproviderbooleanprovider)
 * [`Ergebnis\Test\Util\DataProvider\NullProvider`](https://github.com/ergebnis/test-util#dataprovidernullprovider)
+* [`Ergebnis\Test\Util\DataProvider\StringProvider`](https://github.com/ergebnis/test-util#dataproviderstringprovider)
 
 #### `DataProvider\BooleanProvider`
 


### PR DESCRIPTION
This PR

* [x] adds `StringProvider` to the list in `README.md`

Follows #326.
Follows #328.
