### PR TITLE
Fix: Test data providers directly

### DIFF
--- a/.github/workflows/integrate.yaml
+++ b/.github/workflows/integrate.yaml
@@ -10,8 +10,8 @@ on: # yamllint disable-line rule:truthy
 
 env:
   ERGEBNIS_BOT_NAME: "ergebnis-bot"
-  MIN_COVERED_MSI: 95
-  MIN_MSI: 66
+  MIN_COVERED_MSI: 91
+  MIN_MSI: 91
   PHP_EXTENSIONS: "mbstring"
 
 jobs:

--- a/Makefile
+++ b/Makefile
@@ -1,5 +1,5 @@
-MIN_COVERED_MSI:=95
-MIN_MSI:=66
+MIN_COVERED_MSI:=91
+MIN_MSI:=91
 
 .PHONY: it
 it: coding-standards static-code-analysis tests ## Runs the coding-standards, static-code-analysis, and tests targets

--- a/phpstan-baseline.neon
+++ b/phpstan-baseline.neon
@@ -546,6 +546,11 @@ parameters:
 			path: test/AutoReview/TestCodeTest.php
 
 		-
+			message: "#^Parameter \\#1 \\$argument of class ReflectionClass constructor expects class\\-string\\<T of object\\>\\|T of object, string given\\.$#"
+			count: 2
+			path: test/Unit/DataProvider/AbstractProviderTestCase.php
+
+		-
 			message: "#^Method Ergebnis\\\\Test\\\\Util\\\\Test\\\\Unit\\\\Exception\\\\EmptyValuesTest\\:\\:faker\\(\\) is protected, but since the containing class is final, it can be private\\.$#"
 			count: 1
 			path: test/Unit/Exception/EmptyValuesTest.php

--- a/phpstan.neon
+++ b/phpstan.neon
@@ -5,7 +5,7 @@ parameters:
 	checkMissingIterableValueType: false
 	ergebnis:
 		classesAllowedToBeExtended:
-			- Ergebnis\Test\Util\DataProvider\AbstractDataProvider
+			- Ergebnis\Test\Util\Test\Unit\DataProvider\AbstractProviderTestCase
 			- InvalidArgumentException
 	excludes_analyse:
 		- %currentWorkingDirectory%/test/Fixture/

--- a/test/Unit/DataProvider/AbstractProviderTestCase.php
+++ b/test/Unit/DataProvider/AbstractProviderTestCase.php
@@ -1,0 +1,166 @@
+<?php
+
+declare(strict_types=1);
+
+/**
+ * Copyright (c) 2017-2020 Andreas Möller
+ *
+ * For the full copyright and license information, please view
+ * the LICENSE.md file that was distributed with this source code.
+ *
+ * @see https://github.com/ergebnis/test-util
+ */
+
+namespace Ergebnis\Test\Util\Test\Unit\DataProvider;
+
+use Ergebnis\Test\Util;
+use PHPUnit\Framework;
+
+/**
+ * @internal
+ */
+abstract class AbstractProviderTestCase extends Framework\TestCase
+{
+    use Util\Helper;
+
+    /**
+     * @param array<string, mixed>             $values
+     * @param \Generator<string, array<mixed>> $provider
+     */
+    final protected static function assertProvidesDataForValues(array $values, \Generator $provider): void
+    {
+        self::assertExpectedValuesAreNotEmpty($values);
+
+        $expected = \iterator_to_array(self::provideDataForValues($values));
+
+        $provided = \iterator_to_array($provider);
+
+        self::assertProvidedDataIsNotEmpty($provided);
+
+        self::assertEquals(
+            $expected,
+            $provided,
+            'Failed asserting that a generator yields data for expected values.'
+        );
+    }
+
+    /**
+     * @param \Closure                         $test
+     * @param \Generator<string, array<mixed>> $provider
+     */
+    final protected static function assertProvidesDataForValuesWhere(\Closure $test, \Generator $provider): void
+    {
+        $provided = \iterator_to_array($provider);
+
+        self::assertProvidedDataIsNotEmpty($provided);
+        self::assertProvidedDataContainsArraysWhereFirstElementPassesTest($test, $provided);
+    }
+
+    /**
+     * @param \Closure                         $test
+     * @param \Generator<string, array<mixed>> $provider
+     */
+    final protected static function assertProvidesDataForValuesWhereNot(\Closure $test, \Generator $provider): void
+    {
+        $provided = \iterator_to_array($provider);
+
+        self::assertProvidedDataIsNotEmpty($provided);
+        self::assertProvidedDataContainsArraysWhereFirstElementDoesNotPassTest($test, $provided);
+    }
+
+    /**
+     * @param array $actual
+     */
+    final protected static function assertProvidedDataIsNotEmpty(array $actual): void
+    {
+        self::assertNotEmpty($actual, 'Failed asserting that provided values are not empty.');
+    }
+
+    /**
+     * @param array $values
+     */
+    private static function assertExpectedValuesAreNotEmpty(array $values): void
+    {
+        self::assertNotEmpty($values, 'Failed asserting that expected values are not empty.');
+    }
+
+    /**
+     * @param \Closure             $test
+     * @param array<string, mixed> $provided
+     */
+    private static function assertProvidedDataContainsArraysWhereFirstElementPassesTest(\Closure $test, array $provided): void
+    {
+        self::assertProvidedDataContainsArraysWithOneElement($provided);
+
+        $value = \array_map(static function (array $set) {
+            return \array_shift($set);
+        }, $provided);
+
+        $tested = \array_filter($value, static function ($value) use ($test): bool {
+            return true === $test($value);
+        });
+
+        self::assertEquals(
+            $value,
+            $tested,
+            'Failed asserting that the first value in each array passed the test.'
+        );
+    }
+
+    /**
+     * @param \Closure             $test
+     * @param array<string, mixed> $provided
+     */
+    private static function assertProvidedDataContainsArraysWhereFirstElementDoesNotPassTest(\Closure $test, array $provided): void
+    {
+        self::assertProvidedDataContainsArraysWithOneElement($provided);
+
+        $value = \array_map(static function (array $set) {
+            return \array_shift($set);
+        }, $provided);
+
+        $tested = \array_filter($value, static function ($value) use ($test): bool {
+            return false === $test($value);
+        });
+
+        self::assertEquals(
+            $value,
+            $tested,
+            'Failed asserting that the first value in each array does not pass the test.'
+        );
+    }
+
+    /**
+     * @param array<string, mixed> $provided
+     */
+    private static function assertProvidedDataContainsArraysWithOneElement(array $provided): void
+    {
+        self::assertProvidedDataContainsArraysOnly($provided);
+
+        $setsWhereNumberOfProvidedArgumentsIsNotOne = \array_filter($provided, static function (array $set): bool {
+            return 1 !== \count($set);
+        });
+
+        self::assertEquals(
+            [],
+            $setsWhereNumberOfProvidedArgumentsIsNotOne,
+            'Failed asserting that each set in the provided data contains only a single value.'
+        );
+    }
+
+    /**
+     * @param array<string, mixed> $provided
+     */
+    private static function assertProvidedDataContainsArraysOnly(array $provided): void
+    {
+        $values = \array_filter($provided, static function ($set): bool {
+            return !\is_array($set);
+        });
+
+        self::assertEquals(
+            [],
+            $values,
+            'Failed asserting that each value is an array.'
+        );
+    }
+}

--- a/test/Unit/DataProvider/BooleanProviderTest.php
+++ b/test/Unit/DataProvider/BooleanProviderTest.php
@@ -13,14 +13,14 @@ declare(strict_types=1);
 
 namespace Ergebnis\Test\Util\Test\Unit\DataProvider;
 
-use PHPUnit\Framework;
+use Ergebnis\Test\Util\DataProvider\BooleanProvider;
 
 /**
  * @internal
  *
  * @covers \Ergebnis\Test\Util\DataProvider\BooleanProvider
  */
-final class BooleanProviderTest extends Framework\TestCase
+final class BooleanProviderTest extends AbstractProviderTestCase
 {
     /**
      * @dataProvider \Ergebnis\Test\Util\DataProvider\BooleanProvider::arbitrary()
@@ -30,6 +30,18 @@ final class BooleanProviderTest extends Framework\TestCase
     public function testArbitraryProvidesBoolean($value): void
     {
         self::assertIsBool($value);
+    }
+
+    public function testArbitraryReturnsGeneratorThatProvidesBooleanValues(): void
+    {
+        $values = [
+            'boolean-false' => false,
+            'boolean-true' => true,
+        ];
+
+        $provider = BooleanProvider::arbitrary();
+
+        self::assertProvidesDataForValues($values, $provider);
     }
 
     /**
@@ -42,6 +54,17 @@ final class BooleanProviderTest extends Framework\TestCase
         self::assertFalse($value);
     }
 
+    public function testFalseReturnsGeneratorThatProvidesFalse(): void
+    {
+        $values = [
+            'boolean-false' => false,
+        ];
+
+        $provider = BooleanProvider::false();
+
+        self::assertProvidesDataForValues($values, $provider);
+    }
+
     /**
      * @dataProvider \Ergebnis\Test\Util\DataProvider\BooleanProvider::true()
      *
@@ -50,5 +73,16 @@ final class BooleanProviderTest extends Framework\TestCase
     public function testTrueProvidesTrue($value): void
     {
         self::assertTrue($value);
+    }
+
+    public function testTrueReturnsGeneratorThatProvidesTrue(): void
+    {
+        $values = [
+            'boolean-true' => true,
+        ];
+
+        $provider = BooleanProvider::true();
+
+        self::assertProvidesDataForValues($values, $provider);
     }
 }

--- a/test/Unit/DataProvider/NullProviderTest.php
+++ b/test/Unit/DataProvider/NullProviderTest.php
@@ -13,14 +13,14 @@ declare(strict_types=1);
 
 namespace Ergebnis\Test\Util\Test\Unit\DataProvider;
 
-use PHPUnit\Framework;
+use Ergebnis\Test\Util\DataProvider\NullProvider;
 
 /**
  * @internal
  *
  * @covers \Ergebnis\Test\Util\DataProvider\NullProvider
  */
-final class NullProviderTest extends Framework\TestCase
+final class NullProviderTest extends AbstractProviderTestCase
 {
     /**
      * @dataProvider \Ergebnis\Test\Util\DataProvider\NullProvider::null()
@@ -30,5 +30,16 @@ final class NullProviderTest extends Framework\TestCase
     public function testNullProvidesNull($value): void
     {
         self::assertNull($value);
+    }
+
+    public function testNullReturnsGeneratorThatProvidesNull(): void
+    {
+        $values = [
+            'null' => null,
+        ];
+
+        $provider = NullProvider::null();
+
+        self::assertProvidesDataForValues($values, $provider);
     }
 }

--- a/test/Unit/DataProvider/StringProviderTest.php
+++ b/test/Unit/DataProvider/StringProviderTest.php
@@ -13,14 +13,14 @@ declare(strict_types=1);
 
 namespace Ergebnis\Test\Util\Test\Unit\DataProvider;
 
-use PHPUnit\Framework;
+use Ergebnis\Test\Util\DataProvider\StringProvider;
 
 /**
  * @internal
  *
  * @covers \Ergebnis\Test\Util\DataProvider\StringProvider
  */
-final class StringProviderTest extends Framework\TestCase
+final class StringProviderTest extends AbstractProviderTestCase
 {
     /**
      * @dataProvider \Ergebnis\Test\Util\DataProvider\StringProvider::arbitrary()
@@ -30,6 +30,17 @@ final class StringProviderTest extends Framework\TestCase
     public function testArbitraryProvidesString(string $value): void
     {
         self::assertNotSame('', \trim($value));
+    }
+
+    public function testArbitraryReturnsGeneratorThatProvidesStringsThatAreNeitherEmptyNorBlank(): void
+    {
+        $test = static function (string $value): bool {
+            return '' === \trim($value);
+        };
+
+        $provider = StringProvider::arbitrary();
+
+        self::assertProvidesDataForValuesWhereNot($test, $provider);
     }
 
     /**
@@ -43,6 +54,20 @@ final class StringProviderTest extends Framework\TestCase
         self::assertNotSame('', $value);
     }
 
+    public function testBlankReturnsGeneratorThatProvidesStringsThatAreNeitherEmptyNorBlank(): void
+    {
+        $values = [
+            'string-blank-carriage-return' => "\r",
+            'string-blank-line-feed' => "\n",
+            'string-blank-space' => ' ',
+            'string-blank-tab' => "\t",
+        ];
+
+        $provider = StringProvider::blank();
+
+        self::assertProvidesDataForValues($values, $provider);
+    }
+
     /**
      * @dataProvider \Ergebnis\Test\Util\DataProvider\StringProvider::empty()
      *
@@ -51,6 +76,17 @@ final class StringProviderTest extends Framework\TestCase
     public function testEmptyProvidesEmptyString(string $value): void
     {
         self::assertSame('', $value);
+    }
+
+    public function testEmptyReturnsGeneratorThatProvidesAnEmptyString(): void
+    {
+        $values = [
+            'string-empty' => '',
+        ];
+
+        $provider = StringProvider::empty();
+
+        self::assertProvidesDataForValues($values, $provider);
     }
 
     /**
@@ -63,5 +99,17 @@ final class StringProviderTest extends Framework\TestCase
         self::assertNotSame(\trim($value), $value);
         self::assertNotSame('', $value);
         self::assertNotSame('', \trim($value));
+    }
+
+    public function testUntrimmedReturnsGeneratorThatProvidesUntrimmedStrings(): void
+    {
+        $test = static function (string $value): bool {
+            return \trim($value) !== $value
+                && '' !== \trim($value);
+        };
+
+        $provider = StringProvider::untrimmed();
+
+        self::assertProvidesDataForValuesWhere($test, $provider);
     }
 }


### PR DESCRIPTION
This PR

* [x] tests data providers directly

Follows #326.