### PR TITLE
Fix: Provide all kinds of string values from StringProvider::arbitrary()

### DIFF
--- a/README.md
+++ b/README.md
@@ -162,7 +162,7 @@ For examples, see [`Ergebnis\Test\Util\Test\Unit\DataProvider\NullProviderTest`]
 
 #### `DataProvider\StringProvider`
 
-* `arbitrary()` provides non-empty `string`s without leading and trailing whitespade
+* `arbitrary()` provides arbitrary `string`s
 * `blank()` provides `string`s consisting of whitespace characters only
 * `empty()` provides an empty `string`
 * `untrimmed()` provides `string`s with leading and trailing whitespace

--- a/src/DataProvider/StringProvider.php
+++ b/src/DataProvider/StringProvider.php
@@ -24,9 +24,7 @@ final class StringProvider
      */
     public static function arbitrary(): \Generator
     {
-        yield from self::provideDataForValuesWhereNot(self::values(), static function (string $value): bool {
-            return '' === \trim($value);
-        });
+        yield from self::provideDataForValues(self::values());
     }
 
     /**

--- a/test/Unit/DataProvider/StringProviderTest.php
+++ b/test/Unit/DataProvider/StringProviderTest.php
@@ -26,11 +26,11 @@ final class StringProviderTest extends AbstractProviderTestCase
     /**
      * @dataProvider \Ergebnis\Test\Util\DataProvider\StringProvider::arbitrary()
      *
-     * @param string $value
+     * @param mixed $value
      */
-    public function testArbitraryProvidesString(string $value): void
+    public function testArbitraryProvidesString($value): void
     {
-        self::assertNotSame('', \trim($value));
+        self::assertIsString($value);
     }
 
     public function testArbitraryReturnsGeneratorThatProvidesStringsThatAreNeitherEmptyNorBlank(): void
@@ -42,6 +42,11 @@ final class StringProviderTest extends AbstractProviderTestCase
             'string-arbitrary-word' => Util\DataProvider\Specification\Closure::create(static function (string $value): bool {
                 return '' !== $value && '' !== \trim($value);
             }),
+            'string-blank-carriage-return' => Util\DataProvider\Specification\Identical::create("\r"),
+            'string-blank-line-feed' => Util\DataProvider\Specification\Identical::create("\n"),
+            'string-blank-space' => Util\DataProvider\Specification\Identical::create(' '),
+            'string-blank-tab' => Util\DataProvider\Specification\Identical::create("\t"),
+            'string-empty' => Util\DataProvider\Specification\Identical::create(''),
             'string-untrimmed-carriage-return' => Util\DataProvider\Specification\Pattern::create('/^\r{1,5}\w+\r{1,5}$/'),
             'string-untrimmed-line-feed' => Util\DataProvider\Specification\Pattern::create('/^\n{1,5}\w+\n{1,5}$/'),
             'string-untrimmed-space' => Util\DataProvider\Specification\Pattern::create('/^\s{1,5}\w+\s{1,5}$/'),


### PR DESCRIPTION
This PR

* [x] asserts that `StringProvider::arbitrary()` provides all kinds of `string` values
* [ ] provides all kinds of `string` values from `StringProvider::arbitrary()`

Follows #326.