### PR TITLE
Fix: Add IntProvider to list

### DIFF
--- a/README.md
+++ b/README.md
@@ -102,6 +102,7 @@ In addition to the assertions made available by extending from `PHPUnit\Framewor
 This package provides the following generic data providers:
 
 * [`Ergebnis\Test\Util\DataProvider\BoolProvider`](https://github.com/ergebnis/test-util#dataproviderboolprovider)
+* [`Ergebnis\Test\Util\DataProvider\IntProvider`](https://github.com/ergebnis/test-util#dataproviderintprovider)
 * [`Ergebnis\Test\Util\DataProvider\NullProvider`](https://github.com/ergebnis/test-util#dataprovidernullprovider)
 * [`Ergebnis\Test\Util\DataProvider\StringProvider`](https://github.com/ergebnis/test-util#dataproviderstringprovider)
 


### PR DESCRIPTION
This PR

* [x] adds the `IntProvider` to the list in `README.md`

Follows #326.