### PR TITLE
Fix: Make clear, values are not empty

### DIFF
--- a/README.md
+++ b/README.md
@@ -179,8 +179,8 @@ For examples, see [`Ergebnis\Test\Util\Test\Unit\DataProvider\NullProviderTest`]
 * `arbitrary()` provides arbitrary `string`s
 * `blank()` provides `string`s consisting of whitespace characters only
 * `empty()` provides an empty `string`
-* `trimmed()` provides non-empty `strings` without leading and trailing whitespace
-* `untrimmed()` provides `string`s with leading and trailing whitespace
+* `trimmed()` provides non-empty, non-blank `strings` without leading and trailing whitespace
+* `untrimmed()` provides non-empty, non-blank `string`s with additional leading and trailing whitespace
 
 For examples, see [`Ergebnis\Test\Util\Test\Unit\DataProvider\StringProviderTest`](test/Unit/DataProvider/StringProviderTest.php).
 


### PR DESCRIPTION
This PR

* [x] explains `StringProvider::untrimmed()` better 
