### PR TITLE
Fix: Test method name

### DIFF
--- a/test/Unit/DataProvider/StringProviderTest.php
+++ b/test/Unit/DataProvider/StringProviderTest.php
@@ -33,7 +33,7 @@ final class StringProviderTest extends AbstractProviderTestCase
         self::assertIsString($value);
     }
 
-    public function testArbitraryReturnsGeneratorThatProvidesStringsThatAreNeitherEmptyNorBlank(): void
+    public function testArbitraryReturnsGeneratorThatProvidesArbitraryStrings(): void
     {
         $specifications = [
             'string-arbitrary-sentence' => Util\DataProvider\Specification\Closure::create(static function (string $value): bool {


### PR DESCRIPTION
This PR

* [x] fixes a misleading test method name