### PR TITLE
Enhancement: Add DataProvider\StringProvider::withWhitespace()

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,7 +6,15 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 
 ## Unreleased
 
-For a full diff see [`1.3.1...main`][1.3.1...main].
+For a full diff see [`1.4.0...main`][1.4.0...main].
+
+## [`1.4.0`][1.4.0]
+
+For a full diff see [`1.3.0...1.4.0`][1.3.1...1.4.0].
+
+### Added
+
+* Added `DataProvider\StringProvider::withWhitespace()` ([#374]), by [@localheinz]
 
 ## [`1.3.1`][1.3.1]
 
@@ -127,6 +135,7 @@ For a full diff see [`0.7.0...0.8.0`][0.7.0...0.8.0].
 [1.2.0]: https://github.com/ergebnis/test-util/releases/tag/1.2.0
 [1.3.0]: https://github.com/ergebnis/test-util/releases/tag/1.3.0
 [1.3.1]: https://github.com/ergebnis/test-util/releases/tag/1.3.1
+[1.4.0]: https://github.com/ergebnis/test-util/releases/tag/1.4.0
 
 [0.7.0...0.8.0]: https://github.com/ergebnis/test-util/compare/0.7.0...0.8.0
 [0.8.0...0.9.0]: https://github.com/ergebnis/test-util/compare/0.8.0...0.9.0
@@ -137,7 +146,8 @@ For a full diff see [`0.7.0...0.8.0`][0.7.0...0.8.0].
 [1.1.0...1.2.0]: https://github.com/ergebnis/test-util/compare/1.1.0...1.2.0
 [1.2.0...1.3.0]: https://github.com/ergebnis/test-util/compare/1.2.0...1.3.0
 [1.3.0...1.3.1]: https://github.com/ergebnis/test-util/compare/1.3.0...1.3.1
-[1.3.1...main]: https://github.com/ergebnis/test-util/compare/1.3.1...main
+[1.3.1...1.4.0]: https://github.com/ergebnis/test-util/compare/1.3.1...1.4.0
+[1.4.0...main]: https://github.com/ergebnis/test-util/compare/1.4.0...main
 
 [#118]: https://github.com/ergebnis/test-util/pull/118
 [#119]: https://github.com/ergebnis/test-util/pull/119
@@ -156,6 +166,7 @@ For a full diff see [`0.7.0...0.8.0`][0.7.0...0.8.0].
 [#343]: https://github.com/ergebnis/test-util/pull/343
 [#344]: https://github.com/ergebnis/test-util/pull/344
 [#372]: https://github.com/ergebnis/test-util/pull/372
+[#374]: https://github.com/ergebnis/test-util/pull/374
 
 [@ergebnis]: https://github.com/ergebnis
 [@localheinz]: https://github.com/localheinz

--- a/README.md
+++ b/README.md
@@ -195,6 +195,7 @@ For examples, see [`Ergebnis\Test\Util\Test\Unit\DataProvider\ResourceProviderTe
 * `empty()` provides an empty `string`
 * `trimmed()` provides non-empty, non-blank `strings` without leading and trailing whitespace
 * `untrimmed()` provides non-empty, non-blank `string`s with additional leading and trailing whitespace
+* `withWhitespace()` provides non-empty, non-blank, trimmed `string`s containing whitespace
 
 For examples, see [`Ergebnis\Test\Util\Test\Unit\DataProvider\StringProviderTest`](test/Unit/DataProvider/StringProviderTest.php).
 

--- a/psalm-baseline.xml
+++ b/psalm-baseline.xml
@@ -48,8 +48,8 @@
     </MoreSpecificReturnType>
   </file>
   <file src="src/DataProvider/StringProvider.php">
-    <MixedArgumentTypeCoercion occurrences="2"/>
-    <MoreSpecificReturnType occurrences="5">
+    <MoreSpecificReturnType occurrences="6">
+      <code>\Generator&lt;string, array{0: string}&gt;</code>
       <code>\Generator&lt;string, array{0: string}&gt;</code>
       <code>\Generator&lt;string, array{0: string}&gt;</code>
       <code>\Generator&lt;string, array{0: string}&gt;</code>

--- a/src/DataProvider/StringProvider.php
+++ b/src/DataProvider/StringProvider.php
@@ -71,6 +71,17 @@ final class StringProvider
     }
 
     /**
+     * @return \Generator<string, array{0: string}>
+     */
+    public static function withWhitespace(): \Generator
+    {
+        yield from self::provideDataForValuesWhere(self::values(), static function (string $value): bool {
+            return \trim($value) === $value
+                && 1 === \preg_match('/\s/', $value);
+        });
+    }
+
+    /**
      * @return array<string, string>
      */
     private static function values(): array
@@ -123,14 +134,37 @@ final class StringProvider
             }, $whitespaceCharacters)
         );
 
+        /** @var array<string, string> $withWhitespaceValues */
+        $withWhitespaceValues = \array_combine(
+            \array_map(static function (string $key): string {
+                return \sprintf(
+                    'string-with-whitespace-%s',
+                    $key
+                );
+            }, \array_keys($whitespaceCharacters)),
+            \array_map(static function (string $whitespaceCharacter) use ($faker): string {
+                /** @var array<string> $words */
+                $words = $faker->words($faker->numberBetween(2, 5));
+
+                return \implode(
+                    $whitespaceCharacter,
+                    $words
+                );
+            }, $whitespaceCharacters)
+        );
+
         return \array_merge(
             $arbitraryValues,
             $blankValues,
             $emptyValues,
-            $untrimmedValues
+            $untrimmedValues,
+            $withWhitespaceValues
         );
     }
 
+    /**
+     * @return array<string, string>
+     */
     private static function whitespaceCharacters(): array
     {
         return [

--- a/test/Unit/DataProvider/StringProviderTest.php
+++ b/test/Unit/DataProvider/StringProviderTest.php
@@ -51,6 +51,10 @@ final class StringProviderTest extends AbstractProviderTestCase
             'string-untrimmed-line-feed' => Util\DataProvider\Specification\Pattern::create('/^\n{1,5}\w+\n{1,5}$/'),
             'string-untrimmed-space' => Util\DataProvider\Specification\Pattern::create('/^\s{1,5}\w+\s{1,5}$/'),
             'string-untrimmed-tab' => Util\DataProvider\Specification\Pattern::create('/^\t{1,5}\w+\t{1,5}$/'),
+            'string-with-whitespace-carriage-return' => Util\DataProvider\Specification\Pattern::create('/^\w+(\r+\w+){1,4}$/'),
+            'string-with-whitespace-line-feed' => Util\DataProvider\Specification\Pattern::create('/^\w+(\n+\w+){1,4}$/'),
+            'string-with-whitespace-space' => Util\DataProvider\Specification\Pattern::create('/^\w+(\s+\w+){1,4}$/'),
+            'string-with-whitespace-tab' => Util\DataProvider\Specification\Pattern::create('/^\w+(\t+\w+){1,4}$/'),
         ];
 
         $provider = StringProvider::arbitrary();
@@ -129,6 +133,10 @@ final class StringProviderTest extends AbstractProviderTestCase
             'string-arbitrary-word' => Util\DataProvider\Specification\Closure::create(static function (string $value): bool {
                 return '' !== $value && '' !== \trim($value);
             }),
+            'string-with-whitespace-carriage-return' => Util\DataProvider\Specification\Pattern::create('/^\w+(\r+\w+){1,4}$/'),
+            'string-with-whitespace-line-feed' => Util\DataProvider\Specification\Pattern::create('/^\w+(\n+\w+){1,4}$/'),
+            'string-with-whitespace-space' => Util\DataProvider\Specification\Pattern::create('/^\w+(\s+\w+){1,4}$/'),
+            'string-with-whitespace-tab' => Util\DataProvider\Specification\Pattern::create('/^\w+(\t+\w+){1,4}$/'),
         ];
 
         $provider = StringProvider::trimmed();
@@ -146,6 +154,23 @@ final class StringProviderTest extends AbstractProviderTestCase
         ];
 
         $provider = StringProvider::untrimmed();
+
+        self::assertProvidesDataSetsForValuesSatisfyingSpecifications($specifications, $provider);
+    }
+
+    public function testWithWhitespaceReturnsGeneratorThatProvidesTrimmedStringsWithWhitespace(): void
+    {
+        $specifications = [
+            'string-arbitrary-sentence' => Util\DataProvider\Specification\Closure::create(static function (string $value): bool {
+                return '' !== $value && '' !== \trim($value);
+            }),
+            'string-with-whitespace-carriage-return' => Util\DataProvider\Specification\Pattern::create('/^\w+(\r+\w+){1,4}$/'),
+            'string-with-whitespace-line-feed' => Util\DataProvider\Specification\Pattern::create('/^\w+(\n+\w+){1,4}$/'),
+            'string-with-whitespace-space' => Util\DataProvider\Specification\Pattern::create('/^\w+(\s+\w+){1,4}$/'),
+            'string-with-whitespace-tab' => Util\DataProvider\Specification\Pattern::create('/^\w+(\t+\w+){1,4}$/'),
+        ];
+
+        $provider = StringProvider::withWhitespace();
 
         self::assertProvidesDataSetsForValuesSatisfyingSpecifications($specifications, $provider);
     }


### PR DESCRIPTION
This PR

* [x] adds `DataProvider\StringProvider::withWhitespace()`

💁‍♂️ This can be useful for testing a method that should reject `string`s containing any whitespace characters.