### PR TITLE
Fix: Use Xdebug instead of pcov for collecting code coverage

### DIFF
--- a/.github/CONTRIBUTING.md
+++ b/.github/CONTRIBUTING.md
@@ -51,7 +51,7 @@ to run a dependency analysis.
 
 We are using [`infection/infection`](https://github.com/infection/infection) to ensure a minimum quality of the tests.
 
-Enable `pcov` or `Xdebug` and run
+Enable `Xdebug` and run
 
 ```sh
 $ make mutation-tests

--- a/.github/workflows/integrate.yaml
+++ b/.github/workflows/integrate.yaml
@@ -34,7 +34,7 @@ jobs:
       - name: "Set up PHP"
         uses: "shivammathur/setup-php@2.16.0"
         with:
-          coverage: "pcov"
+          coverage: "xdebug"
           extensions: "${{ env.PHP_EXTENSIONS }}"
           php-version: "${{ matrix.php-version }}"
 
@@ -56,7 +56,7 @@ jobs:
         with:
           dependencies: "${{ matrix.dependencies }}"
 
-      - name: "Collect code coverage with pcov and phpunit/phpunit"
+      - name: "Collect code coverage with Xdebug and phpunit/phpunit"
         run: "vendor/bin/phpunit --configuration=test/Unit/phpunit.xml --coverage-clover=.build/phpunit/logs/clover.xml"
 
       - name: "Send code coverage report to Codecov.io"
@@ -194,7 +194,7 @@ jobs:
       - name: "Set up PHP"
         uses: "shivammathur/setup-php@2.16.0"
         with:
-          coverage: "pcov"
+          coverage: "xdebug"
           extensions: "${{ env.PHP_EXTENSIONS }}"
           php-version: "${{ matrix.php-version }}"
 
@@ -213,7 +213,7 @@ jobs:
         with:
           dependencies: "${{ matrix.dependencies }}"
 
-      - name: "Run mutation tests with pcov and infection/infection"
+      - name: "Run mutation tests with Xdebug and infection/infection"
         run: "vendor/bin/infection --ignore-msi-with-no-mutations --min-covered-msi=${{ env.MIN_COVERED_MSI }} --min-msi=${{ env.MIN_MSI }}"
 
   static-code-analysis:


### PR DESCRIPTION
This pull request

- [x] uses `Xdebug` instead of `pcov` for collecting code coverage